### PR TITLE
Add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to `likeminds-chat-reactnative-traya`, generated from its GitHub Releases.
+
+Full release history: https://github.com/LikeMindsCommunity/likeminds-chat-reactnative-traya/releases
+
+---
+
+## [0.5.0] - 2024-02-07
+
+- Traya Design Changes
+
+[Release](https://github.com/LikeMindsCommunity/likeminds-chat-reactnative-traya/releases/tag/v0.5.0)


### PR DESCRIPTION
Generated from this repo's GitHub Releases: every published version with its date and release notes, newest first.

Anyone upgrading a published package currently has to read git history or click through the Releases page to find out what changed. This puts it in the repo where people look for it.

Nothing is invented - each entry is the release body as written, with headings demoted one level so they nest under the version. Each entry links back to its release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)